### PR TITLE
Add support for enabling or disabling SSLCert verification

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for pip/poetry
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install poetry
       run: |
-        pip install poetry==1.0.9
+        pip install poetry==1.1.14
 
     - name: Build package and publish to PyPi
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     container: python:${{ matrix.python }}
     strategy:
       matrix:
-        python: [3.8, 3.9, 3.10]
+        python: [3.8, 3.9, 3.10.0]
 
     services:
       rabbitmq:
@@ -46,7 +46,7 @@ jobs:
     container: python:${{ matrix.python }}
     strategy:
       matrix:
-        python: [3.8, 3.9, 3.10]
+        python: [3.8, 3.9, 3.10.0]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     container: python:${{ matrix.python }}
     strategy:
       matrix:
-        python: [3.8, 3.9, 3.10.0]
+        python: [3.8, 3.9, 3.10]
 
     services:
       rabbitmq:
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install poetry
       run: |
-        pip install poetry==1.0.9
+        pip install poetry==1.1.14
 
     - name: Install dependencies
       run: |
@@ -46,14 +46,14 @@ jobs:
     container: python:${{ matrix.python }}
     strategy:
       matrix:
-        python: [3.8, 3.9, 3.10.0]
+        python: [3.8, 3.9, 3.10]
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Install poetry
         run: |
-          pip install poetry==1.0.9
+          pip install poetry==1.1.14
 
       - name: Install dependencies
         run: |

--- a/poetry.lock
+++ b/poetry.lock
@@ -93,7 +93,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "requests"
-version = "2.27.1"
+version = "2.28.1"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
@@ -199,8 +199,8 @@ pyflakes = [
     {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
 ]
 requests = [
-    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
-    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+    {file = "requests-2.28.1-py2.py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-requests = "^2.24.0"
+requests = "^2.28.1"
 
 [tool.poetry.dev-dependencies]
 # tests

--- a/rabbitmq_admin/base.py
+++ b/rabbitmq_admin/base.py
@@ -1,7 +1,7 @@
 import json
 import requests
 from copy import deepcopy
-
+from urllib3.exceptions import InsecureRequestWarning
 
 class Resource(object):
     """
@@ -12,7 +12,7 @@ class Resource(object):
     # ```['GET', 'PUT', 'POST', 'DELETE']``"""
     # ALLOWED_METHODS = []
 
-    def __init__(self, host, port, auth, scheme='http', timeout=10):
+    def __init__(self, host, port, auth, scheme='http', timeout=10, verify=True):
         """
         :param host: The RabbitMQ API host to connect to
         :type host: str
@@ -29,12 +29,19 @@ class Resource(object):
             ``('username', 'password')``
         :type auth: Requests auth
 
+        :param verify: verifies SSL certificates for HTTPS requests
+        :type verify: bool
+
         .. _Requests' authentication:
         http://docs.python-requests.org/en/latest/user/authentication/
         """
         self.url = f'{scheme}://{host}:{port}'
         self.auth = auth
         self.timeout = timeout
+        self.verify = verify
+
+        if not self.verify:
+            requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
 
         self.headers = {
             'Content-type': 'application/json',
@@ -52,6 +59,7 @@ class Resource(object):
         headers.update(kwargs.get('headers', {}))
         kwargs['headers'] = headers
         kwargs['timeout'] = self.timeout
+        kwargs['verify'] = self.verify
         return self._get(**kwargs)
 
     def _get(self, *args, **kwargs):
@@ -79,6 +87,7 @@ class Resource(object):
         headers.update(kwargs.get('headers', {}))
         kwargs['headers'] = headers
         kwargs['timeout'] = self.timeout
+        kwargs['verify'] = self.verify
         self._put(**kwargs)
 
     def _put(self, *args, **kwargs):
@@ -106,6 +115,7 @@ class Resource(object):
         headers.update(kwargs.get('headers', {}))
         kwargs['headers'] = headers
         kwargs['timeout'] = self.timeout
+        kwargs['verify'] = self.verify
         return self._post(**kwargs)
 
     def _post(self, *args, **kwargs):
@@ -134,6 +144,7 @@ class Resource(object):
         headers.update(kwargs.get('headers', {}))
         kwargs['headers'] = headers
         kwargs['timeout'] = self.timeout
+        kwargs['verify'] = self.verify
         self._delete(**kwargs)
 
     def _delete(self, *args, **kwargs):

--- a/rabbitmq_admin/base.py
+++ b/rabbitmq_admin/base.py
@@ -1,7 +1,7 @@
 import json
 import requests
+import urllib3
 from copy import deepcopy
-from urllib3.exceptions import InsecureRequestWarning
 
 class Resource(object):
     """
@@ -41,7 +41,7 @@ class Resource(object):
         self.verify = verify
 
         if not self.verify:
-            requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
         self.headers = {
             'Content-type': 'application/json',


### PR DESCRIPTION
* Add support for dependabot to manage pip/poetry dependencies
* Add support for `verify` to Enable/Disable SSL Cert verification for `requests` (Defaults to True)
* Bump  `poetry` to 1.1.14
* Bump `requests` to 2.28.1

Source for `urllib3` warning was taken from here: https://stackoverflow.com/a/28002687

Closes #12 